### PR TITLE
Changing Sonar's widget, lineCoverage to coverage

### DIFF
--- a/UI/src/components/widgets/codeanalysis/view.js
+++ b/UI/src/components/widgets/codeanalysis/view.js
@@ -105,9 +105,9 @@
                 getMetric(caData.metrics, 'tests', 'Tests')
             ];
 
-            ctrl.lineCoverage = getMetric(caData.metrics, 'line_coverage');
+            ctrl.codeCoverage = getMetric(caData.metrics, 'coverage');
 
-            coveragePieChart(ctrl.lineCoverage);
+            coveragePieChart(ctrl.codeCoverage);
 
             deferred.resolve(response.lastUpdated);
             return deferred.promise;


### PR DESCRIPTION
coverage instead line coverage is better, due to coverage show us how many roads on our code logic are coverage by tests